### PR TITLE
Allow subset JSON languages

### DIFF
--- a/extension/useAutoStart.ts
+++ b/extension/useAutoStart.ts
@@ -8,7 +8,7 @@ export function useAutoStart() {
     if (!autoStart.value || !activeTextEditor.value)
       return
     const doc = activeTextEditor.value.document
-    if (doc.languageId === 'json' && doc.uri.fsPath.toLowerCase().endsWith('.tmlanguage.json'))
+    if (doc.languageId.includes('json') && doc.uri.fsPath.toLowerCase().endsWith('.tmlanguage.json'))
       usePreviewer(activeTextEditor.value)
   })
 }


### PR DESCRIPTION
nice extension 🙌

This allows the extension to still work on subset JSON languages
as long as they contain the string `json` in their `languageId`
eg. `jsonc`, `jsonl`, `json-textmate`, `json-tmlanguage`

enables compatibility with https://marketplace.visualstudio.com/items?itemName=RedCMD.tmlanguage-syntax-highlighter and https://marketplace.visualstudio.com/items?itemName=pedro-w.tmlanguage

your extension will still only initial activate on `json`
other extensions can use `vscode.extensions.getExtension("kermanx.tmlanguage-previewer").activate()` to manually activate it

unless you want to add them to `"activationEvents"` aswell
https://github.com/kermanx/tmLanguage-Previewer/blob/d6ad0ac8ed7992d32994f95276c1c7491cb9546d/package.json#L27-L30
